### PR TITLE
Update dane_fail_list.dat

### DIFF
--- a/dane_fail_list.dat
+++ b/dane_fail_list.dat
@@ -30,3 +30,8 @@ domaine-ala.com
 efflam.net
 edgtslfcbngq6sk.space
 edgtslfcbngq6sk.top
+
+# 20180323 - All TLSA RRs failed
+kassoft.eu
+0pc.eu
+stansoft.bg


### PR DESCRIPTION
the domains publish TLSA records not matching the current certificate(s)
checked by https://dane.sys4.de and posttls-finter